### PR TITLE
Add 3 column layout, accordion components and a navbar component

### DIFF
--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,0 +1,41 @@
+import { Disclosure } from "@headlessui/react";
+import { ChevronRightIcon } from "@heroicons/react/20/solid";
+
+interface AccordionContainer {
+  children: React.ReactElement;
+}
+export const AccordionContainer = ({ children }: AccordionContainer) => {
+  return (
+    <div className="w-full px-4 pt-16">
+      {/* use max-w-md to contrain width */}
+      <div className="mx-auto w-full rounded-2xl bg-white p-2">{children}</div>
+    </div>
+  );
+};
+
+interface Accordion {
+  question: string;
+  answer: string | React.ReactNode;
+  defaultOpen?: boolean;
+}
+export const Accordion = ({ question, answer, defaultOpen }: Accordion) => {
+  return (
+    <Disclosure defaultOpen={defaultOpen}>
+      {({ open }) => (
+        <>
+          <Disclosure.Button className="flex w-full justify-between rounded-lg bg-indigo-100 px-4 py-2 text-left text-sm font-medium text-indigo-900 hover:bg-indigo-200 focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75">
+            <span>{question}</span>
+            <ChevronRightIcon
+              className={`${
+                open ? "rotate-90 transform" : ""
+              } h-5 w-5 text-indigo-500`}
+            />
+          </Disclosure.Button>
+          <Disclosure.Panel className="px-4 pt-4 pb-2 text-sm text-gray-500">
+            {answer}
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+};

--- a/components/NavBar/Nav.tsx
+++ b/components/NavBar/Nav.tsx
@@ -1,0 +1,198 @@
+import { Fragment } from "react";
+import { Disclosure, Menu, Transition } from "@headlessui/react";
+import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
+import { Bars3CenterLeftIcon, XMarkIcon } from "@heroicons/react/24/outline";
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export const NavBar = () => {
+  return (
+    <Disclosure as="nav" className="flex-shrink-0 bg-indigo-600">
+      {({ open }) => (
+        <>
+          <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
+            <div className="relative flex h-16 items-center justify-between">
+              {/* Logo section */}
+              <div className="flex items-center px-2 lg:px-0 xl:w-64">
+                <div className="flex-shrink-0">
+                  <img
+                    className="h-8 w-auto"
+                    src="https://tailwindui.com/img/logos/mark.svg?color=indigo&shade=300"
+                    alt="Your Company"
+                  />
+                </div>
+              </div>
+
+              {/* Search section */}
+              <div className="flex flex-1 justify-center lg:justify-end">
+                <div className="w-full px-2 lg:px-6">
+                  <label htmlFor="search" className="sr-only">
+                    Search projects
+                  </label>
+                  <div className="relative text-indigo-200 focus-within:text-gray-400">
+                    <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                      <MagnifyingGlassIcon
+                        className="h-5 w-5"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <input
+                      id="search"
+                      name="search"
+                      className="block w-full rounded-md border border-transparent bg-indigo-400 bg-opacity-25 py-2 pl-10 pr-3 leading-5 text-indigo-100 placeholder-indigo-200 focus:bg-white focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-0 sm:text-sm"
+                      placeholder="Search projects"
+                      type="search"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="flex lg:hidden">
+                {/* Mobile menu button */}
+                <Disclosure.Button className="inline-flex items-center justify-center rounded-md bg-indigo-600 p-2 text-indigo-400 hover:bg-indigo-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-indigo-600">
+                  <span className="sr-only">Open main menu</span>
+                  {open ? (
+                    <XMarkIcon className="block h-6 w-6" aria-hidden="true" />
+                  ) : (
+                    <Bars3CenterLeftIcon
+                      className="block h-6 w-6"
+                      aria-hidden="true"
+                    />
+                  )}
+                </Disclosure.Button>
+              </div>
+              {/* Links section */}
+              <div className="hidden lg:block lg:w-80">
+                <div className="flex items-center justify-end">
+                  <div className="flex">
+                    <a
+                      href="#"
+                      className="rounded-md px-3 py-2 text-sm font-medium text-indigo-200 hover:text-white"
+                    >
+                      Documentation
+                    </a>
+                    <a
+                      href="#"
+                      className="rounded-md px-3 py-2 text-sm font-medium text-indigo-200 hover:text-white"
+                    >
+                      Support
+                    </a>
+                  </div>
+                  {/* Profile dropdown */}
+                  <Menu as="div" className="relative ml-4 flex-shrink-0">
+                    <div>
+                      <Menu.Button className="flex rounded-full bg-indigo-700 text-sm text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-indigo-700">
+                        <span className="sr-only">Open user menu</span>
+                        <img
+                          className="h-8 w-8 rounded-full"
+                          src="https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80"
+                          alt=""
+                        />
+                      </Menu.Button>
+                    </div>
+                    <Transition
+                      as={Fragment}
+                      enter="transition ease-out duration-100"
+                      enterFrom="transform opacity-0 scale-95"
+                      enterTo="transform opacity-100 scale-100"
+                      leave="transition ease-in duration-75"
+                      leaveFrom="transform opacity-100 scale-100"
+                      leaveTo="transform opacity-0 scale-95"
+                    >
+                      <Menu.Items className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                        <Menu.Item>
+                          {({ active }) => (
+                            <a
+                              href="#"
+                              className={classNames(
+                                active ? "bg-gray-100" : "",
+                                "block px-4 py-2 text-sm text-gray-700"
+                              )}
+                            >
+                              View Profile
+                            </a>
+                          )}
+                        </Menu.Item>
+                        <Menu.Item>
+                          {({ active }) => (
+                            <a
+                              href="#"
+                              className={classNames(
+                                active ? "bg-gray-100" : "",
+                                "block px-4 py-2 text-sm text-gray-700"
+                              )}
+                            >
+                              Settings
+                            </a>
+                          )}
+                        </Menu.Item>
+                        <Menu.Item>
+                          {({ active }) => (
+                            <a
+                              href="#"
+                              className={classNames(
+                                active ? "bg-gray-100" : "",
+                                "block px-4 py-2 text-sm text-gray-700"
+                              )}
+                            >
+                              Logout
+                            </a>
+                          )}
+                        </Menu.Item>
+                      </Menu.Items>
+                    </Transition>
+                  </Menu>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <Disclosure.Panel className="lg:hidden">
+            <div className="px-2 pt-2 pb-3">
+              <Disclosure.Button
+                as="a"
+                href="#"
+                className="block rounded-md bg-indigo-800 px-3 py-2 text-base font-medium text-white"
+              >
+                Dashboard
+              </Disclosure.Button>
+              <Disclosure.Button
+                as="a"
+                href="#"
+                className="mt-1 block rounded-md px-3 py-2 text-base font-medium text-indigo-200 hover:bg-indigo-600 hover:text-indigo-100"
+              >
+                Support
+              </Disclosure.Button>
+            </div>
+            <div className="border-t border-indigo-800 pt-4 pb-3">
+              <div className="px-2">
+                <Disclosure.Button
+                  as="a"
+                  href="#"
+                  className="block rounded-md px-3 py-2 text-base font-medium text-indigo-200 hover:bg-indigo-600 hover:text-indigo-100"
+                >
+                  Your Profile
+                </Disclosure.Button>
+                <Disclosure.Button
+                  as="a"
+                  href="#"
+                  className="mt-1 block rounded-md px-3 py-2 text-base font-medium text-indigo-200 hover:bg-indigo-600 hover:text-indigo-100"
+                >
+                  Settings
+                </Disclosure.Button>
+                <Disclosure.Button
+                  as="a"
+                  href="#"
+                  className="mt-1 block rounded-md px-3 py-2 text-base font-medium text-indigo-200 hover:bg-indigo-600 hover:text-indigo-100"
+                >
+                  Sign out
+                </Disclosure.Button>
+              </div>
+            </div>
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+};

--- a/components/Question.tsx
+++ b/components/Question.tsx
@@ -1,7 +1,9 @@
 interface Question {
-  title: string;
+  title?: string;
   placeholder: string;
 }
+// use this https://tailwindui.com/components/application-ui/application-shells/multi-column
+// disclosure component in headlessui
 export const Question = ({ title, placeholder }: Question) => {
   return (
     <div className="mb-4">
@@ -26,7 +28,7 @@ export const Question = ({ title, placeholder }: Question) => {
 };
 
 interface QuestionSplit {
-  title: string;
+  title?: string;
   placeholder: string;
   titleOne: string;
   titleTwo: string;

--- a/components/QuestionList.tsx
+++ b/components/QuestionList.tsx
@@ -1,4 +1,5 @@
 import { Question as QuestionType } from "../config/questions";
+import { Accordion } from "./Accordion/Accordion";
 import { Question, QuestionSplit } from "./Question";
 
 interface QuestionList {
@@ -6,27 +7,33 @@ interface QuestionList {
 }
 export const QuestionList = ({ questions }: QuestionList) => {
   return (
-    <>
-      {questions.map((question) => {
+    <div className="space-y-2">
+      {questions.map((question, index) => {
         if (question.questionType === "split") {
           return (
-            <QuestionSplit
+            <Accordion
               key={question.title}
-              title={question.title}
-              placeholder={question.placeholder}
-              titleOne={question.titleOne}
-              titleTwo={question.titleTwo}
+              question={question.title}
+              answer={
+                <QuestionSplit
+                  key={question.title}
+                  placeholder={question.placeholder}
+                  titleOne={question.titleOne}
+                  titleTwo={question.titleTwo}
+                />
+              }
             />
           );
         }
         return (
-          <Question
+          <Accordion
+            defaultOpen={index === 0}
             key={question.title}
-            title={question.title}
-            placeholder={question.placeholder}
+            question={question.title}
+            answer={<Question placeholder={question.placeholder} />}
           />
         );
       })}
-    </>
+    </div>
   );
 };

--- a/components/ThreeColumnLayout.tsx
+++ b/components/ThreeColumnLayout.tsx
@@ -1,0 +1,65 @@
+import { NavBar } from "../components/NavBar/Nav";
+
+interface ThreeColumnLayout {
+  children: React.ReactElement;
+}
+export const ThreeColumnLayout = ({ children }: ThreeColumnLayout) => {
+  return (
+    <>
+      {/* Background color split screen for large screens */}
+      <div
+        className="fixed top-0 left-0 h-full w-1/2 bg-white"
+        aria-hidden="true"
+      />
+      <div
+        className="fixed top-0 right-0 h-full w-1/2 bg-gray-50"
+        aria-hidden="true"
+      />
+      <div className="relative flex min-h-screen flex-col">
+        {/* Navbar */}
+        <NavBar />
+
+        {/* 3 column wrapper */}
+        {/* adjust this with max-width as needed max-w-7xl */}
+        <div className="mx-auto w-full  flex-grow lg:flex xl:px-8">
+          {/* Left sidebar & main wrapper */}
+          <div className="min-w-0 flex-1 bg-white xl:flex">
+            <div className="border-b border-gray-200 bg-white xl:w-64 xl:flex-shrink-0 xl:border-b-0 xl:border-r xl:border-gray-200">
+              <div className="h-full py-6 pl-4 pr-6 sm:pl-6 lg:pl-8 xl:pl-0">
+                {/* Start left column area */}
+                <div className="relative h-full" style={{ minHeight: "12rem" }}>
+                  <div className="absolute inset-0 rounded-lg border-2 border-dashed border-gray-200" />
+                </div>
+                {/* End left column area */}
+              </div>
+            </div>
+
+            <div className="bg-white lg:min-w-0 lg:flex-1">
+              <div className="h-full py-6 px-4 sm:px-6 lg:px-8">
+                {/* Start main area*/}
+                <div className="relative h-full" style={{ minHeight: "36rem" }}>
+                  <div className="absolute inset-0 rounded-lg border-2 border-dashed border-gray-200">
+                    {children}
+                  </div>
+                </div>
+                {/* End main area */}
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-gray-50 pr-4 sm:pr-6 lg:flex-shrink-0 lg:border-l lg:border-gray-200 lg:pr-8 xl:pr-0">
+            <div className="h-full py-6 pl-6 lg:w-80">
+              {/* Start right column area */}
+              <div className="relative h-full" style={{ minHeight: "16rem" }}>
+                <div className="absolute inset-0 rounded-lg border-2 border-dashed border-gray-200" />
+              </div>
+              {/* End right column area */}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ThreeColumnLayout;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "monthly-reviews",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^1.7.3",
+        "@heroicons/react": "^2.0.12",
         "@tailwindcss/forms": "^0.5.3",
         "next": "12.3.1",
         "react": "18.2.0",
@@ -72,6 +74,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.3.tgz",
+      "integrity": "sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.12.tgz",
+      "integrity": "sha512-FZxKh3i9aKIDxyALTgIpSF2t6V6/eZfF5mRu41QlwkX3Oxzecdm1u6dpft6PQGxIBwO7TKYWaMAYYL8mp/EaOg==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3673,6 +3695,18 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@headlessui/react": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.3.tgz",
+      "integrity": "sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==",
+      "requires": {}
+    },
+    "@heroicons/react": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.12.tgz",
+      "integrity": "sha512-FZxKh3i9aKIDxyALTgIpSF2t6V6/eZfF5mRu41QlwkX3Oxzecdm1u6dpft6PQGxIBwO7TKYWaMAYYL8mp/EaOg==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.7",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.3",
+    "@heroicons/react": "^2.0.12",
     "@tailwindcss/forms": "^0.5.3",
     "next": "12.3.1",
     "react": "18.2.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,10 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import { Question, QuestionSplit } from "../components/Question";
+import { NavBar } from "../components/NavBar/Nav";
 import { QuestionList } from "../components/QuestionList";
-import { reviewQuestions, SplitQuestion } from "../config/questions";
+import { reviewQuestions } from "../config/questions";
 
 const Home: NextPage = () => {
-  const singleQuestion = reviewQuestions[0];
-  const splitQuestion = reviewQuestions[2] as SplitQuestion;
   return (
     // <nav>
     //   {/* Nav bar goes here */}

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,0 +1,19 @@
+import test from "node:test";
+import { QuestionList } from "../components/QuestionList";
+import { ThreeColumnLayout } from "../components/ThreeColumnLayout";
+import { reviewQuestions } from "../config/questions";
+
+const Test = () => {
+  return (
+    <ThreeColumnLayout>
+      <>
+        <h1 className="text-3xl font-extrabold tracking-widest mb-6">
+          October 18th, 2022
+        </h1>
+        <QuestionList questions={reviewQuestions} />
+      </>
+    </ThreeColumnLayout>
+  );
+};
+
+export default Test;


### PR DESCRIPTION
Introduces an example page, `/test` which shows a 3 column layout and navigation bar

- adds headless UI for the accordion component (or Disclosure in their docs)
- heroicons for the icons